### PR TITLE
Add auth status endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -300,6 +300,29 @@ def whoami():
         logging.error(f"Whoami error: {str(e)}")
         return jsonify({"message": f"An error occurred: {str(e)}"}), 500
 
+# New route to check authentication status
+@app.route("/api/auth/status", methods=["GET"])
+@jwt_required(optional=True)
+def auth_status():
+    try:
+        user_id = get_jwt_identity()
+        if user_id:
+            user = User.query.get(user_id)
+            if user:
+                return jsonify({
+                    "authenticated": True,
+                    "user": {
+                        "id": user.id,
+                        "name": user.name,
+                        "email": user.email,
+                        "user_type": user.user_type,
+                    },
+                }), 200
+        return jsonify({"authenticated": False}), 200
+    except Exception as e:
+        logging.error(f"Auth status error: {str(e)}")
+        return jsonify({"message": f"An error occurred: {str(e)}"}), 500
+
 # --- Template & Dashboard Routes ---
 @app.route("/")
 def home():

--- a/templates/market.html
+++ b/templates/market.html
@@ -506,12 +506,15 @@
     // Check if user is logged in and update header
     async function checkLoginStatus() {
       try {
-        const response = await fetch('/whoami', {
+        const response = await fetch('/api/auth/status', {
           method: 'GET',
-          credentials: 'include'
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json'
+          }
         });
         const data = await response.json();
-        if (response.ok) {
+        if (response.ok && data.authenticated) {
           const user = data.user;
           const authLink = document.getElementById('auth-link');
           authLink.innerHTML = `
@@ -519,8 +522,6 @@
               <i class="fas fa-user"></i> ${user.name}
             </a>
           `;
-        } else {
-          console.log('Not logged in:', data.message);
         }
       } catch (error) {
         console.error('Error checking login status:', error);

--- a/templates/properties.html
+++ b/templates/properties.html
@@ -618,24 +618,23 @@
       // Check if user is logged in and update header
       async function checkLoginStatus() {
         try {
-          const response = await fetch('/whoami', {
-            method: 'GET',
-            credentials: 'include'  // Send JWT cookies
-          });
-          const data = await response.json();
-          if (response.ok) {
-            const user = data.user;
-            const authLink = document.getElementById('auth-link');
-            authLink.innerHTML = `
-              <a class="nav-link" href="/dashboard/${user.user_type.replace('/', '-').toLowerCase()}"><i class="fas fa-user"></i> ${user.name}</a>
-            `;
-          } else {
-            console.log('Not logged in:', data.message);
-          }
-        } catch (error) {
-          console.error('Error checking login status:', error);
+        const response = await fetch('/api/auth/status', {
+          method: 'GET',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' }
+        });
+        const data = await response.json();
+        if (response.ok && data.authenticated) {
+          const user = data.user;
+          const authLink = document.getElementById('auth-link');
+          authLink.innerHTML = `
+            <a class="nav-link" href="/dashboard/${user.user_type.replace('/', '-').toLowerCase()}"><i class="fas fa-user"></i> ${user.name}</a>
+          `;
         }
+      } catch (error) {
+        console.error('Error checking login status:', error);
       }
+    }
 
       // Run on page load
       checkLoginStatus();

--- a/templates/signin.html
+++ b/templates/signin.html
@@ -500,12 +500,13 @@
     // Check login status
     async function checkLoginStatus() {
       try {
-        const response = await fetch('/whoami', {
+        const response = await fetch('/api/auth/status', {
           method: 'GET',
-          credentials: 'include'
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' }
         });
         const data = await response.json();
-        if (response.ok) {
+        if (response.ok && data.authenticated) {
           const user = data.user;
           const authLink = document.getElementById('auth-link');
           authLink.innerHTML = `
@@ -513,8 +514,6 @@
               <i class="fas fa-user"></i> ${user.name}
             </a>
           `;
-        } else {
-          console.log('Not logged in:', data.message);
         }
       } catch (error) {
         console.error('Error checking login status:', error);


### PR DESCRIPTION
## Summary
- add `/api/auth/status` to verify authentication via optional JWT cookie
- update templates to use new authentication status endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840a19b6e9483288ddaeafc4a88fd15