### PR TITLE
Add README and auth tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Real Estate Backend
+
+This project is a simple Flask backend for a real estate website. The application provides authentication and basic property management APIs.
+
+## Setup
+
+1. **Python version**: The project requires **Python 3.11+**.
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Environment variables**:
+   - `DATABASE_URL` – Database connection string (default: `sqlite:///properties.db`).
+   - `JWT_SECRET_KEY` – Secret key used to sign JWT tokens.
+   - `GOOGLE_CLIENT_ID` – Client ID for Google OAuth (optional).
+   - `PORT` – Port for the development server (default: `5000`).
+
+You can create a `.env` file or export these variables in your shell before running the server.
+
+## Running the Server
+
+Execute the following command:
+
+```bash
+python main.py
+```
+
+The application will start on `http://localhost:5000` unless a different `PORT` is specified.
+
+## Running Tests
+
+Tests are written with **pytest** and located in the `tests/` directory. Run them with:
+
+```bash
+pytest
+```
+
+The tests use an in-memory SQLite database and cover basic authentication endpoints (signup and signin).
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+import importlib.util
+from pathlib import Path
+
+# Configure environment for tests
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+# Import the app module from the repository directly to avoid conflicts with any
+# installed packages named "app".
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+User = app_module.User
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_signup_and_signin(client):
+    resp = client.post(
+        "/signup",
+        json={
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "password123",
+            "user_type": "Buyer/Renter",
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.get_json()["message"] == "Signed up successfully"
+
+    resp = client.post(
+        "/signin",
+        json={"email": "test@example.com", "password": "password123"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["message"] == "Signed in successfully"
+


### PR DESCRIPTION
## Summary
- add instructions on setup, environment variables, running and testing
- provide pytest-based tests for signup and signin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840aca8a56c832884b59bf5c900d4c4