### PR TITLE
Add placeholder pages and valid route handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 import logging
 from datetime import timedelta
 
-from flask import Flask, jsonify, request, render_template, make_response
+from flask import Flask, jsonify, request, render_template, make_response, abort
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_jwt_extended import (
@@ -381,6 +381,43 @@ def privacy_page():
 @app.route("/agents")
 def agents_page():
     return render_template("agents.html")
+
+@app.route("/about")
+def about_page():
+    return render_template("about.html")
+
+@app.route("/contact")
+def contact_page():
+    return render_template("contact.html")
+
+@app.route("/mortgage")
+def mortgage_page():
+    return render_template("mortgage.html")
+
+@app.route("/market-trends")
+def market_trends_page():
+    return render_template("market-trends.html")
+
+@app.route("/blog")
+def blog_page():
+    return render_template("blog.html")
+
+@app.route("/favorites")
+def favorites_page():
+    return render_template("favorites.html")
+
+@app.route("/dashboard/<user_type>")
+def dashboard_page(user_type):
+    template_map = {
+        "agency": "dashboard-agency.html",
+        "buyer-renter": "dashboard-buyer-renter.html",
+        "independent": "dashboard-independent.html",
+        "landlord": "dashboard-landlord.html",
+    }
+    template = template_map.get(user_type)
+    if not template:
+        abort(404)
+    return render_template(template)
 
 # --- API Endpoints for Properties, Favorites, Evaluation, and Alerts ---
 @app.route("/api/properties", methods=["GET"])

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About Us</title>
+</head>
+<body>
+  <h1>About Us</h1>
+  <p>This page is under construction.</p>
+</body>
+</html>

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -1321,7 +1321,7 @@
           if (response.ok && data.authenticated) {
             const authLink = document.getElementById('auth-link');
             const user = data.user;
-            const dashboardLink = user.user_type === 'agent' ? '/agent-dashboard' : '/user-dashboard';
+            const dashboardLink = '/dashboard/'.concat(user.user_type.replace('/', '-').toLowerCase());
             
             authLink.innerHTML = `
               <div class="dropdown">

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Real Estate Blog</title>
+</head>
+<body>
+  <h1>Real Estate Blog</h1>
+  <p>This page is under construction.</p>
+</body>
+</html>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contact Us</title>
+</head>
+<body>
+  <h1>Contact Us</h1>
+  <p>This page is under construction.</p>
+</body>
+</html>

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Favorites</title>
+</head>
+<body>
+  <h1>Favorites</h1>
+  <p>This page is under construction.</p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1483,7 +1483,7 @@
         if (response.ok && data.authenticated) {
           const authLink = document.getElementById('auth-link');
           const user = data.user;
-          const dashboardLink = user.user_type === 'agent' ? '/agent-dashboard' : '/user-dashboard';
+          const dashboardLink = '/dashboard/'.concat(user.user_type.replace('/', '-').toLowerCase());
           
           authLink.innerHTML = `
             <div class="dropdown">

--- a/templates/market-trends.html
+++ b/templates/market-trends.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Market Trends</title>
+</head>
+<body>
+  <h1>Market Trends</h1>
+  <p>This page is under construction.</p>
+</body>
+</html>

--- a/templates/mortgage.html
+++ b/templates/mortgage.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mortgage Tools</title>
+</head>
+<body>
+  <h1>Mortgage Tools</h1>
+  <p>This page is under construction.</p>
+</body>
+</html>

--- a/templates/sell.html
+++ b/templates/sell.html
@@ -1060,7 +1060,7 @@
         if (response.ok && data.authenticated) {
           const authLink = document.getElementById('auth-link');
           const user = data.user;
-          const dashboardLink = user.user_type === 'agent' ? '/agent-dashboard' : '/user-dashboard';
+          const dashboardLink = '/dashboard/'.concat(user.user_type.replace('/', '-').toLowerCase());
           
           authLink.innerHTML = `
             <div class="dropdown">


### PR DESCRIPTION
## Summary
- add placeholder templates for About, Contact, Mortgage Tools, Market Trends, Blog and Favorites
- add routes for new pages and for user dashboards
- expose dashboard route mapping
- update login scripts to point at `/dashboard/<user_type>`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840b5db0d508328829e73da2e244490