### PR TITLE
Add user data to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -394,7 +394,24 @@ def dashboard(role):
     template = templates.get(role)
     if not template:
         abort(404)
-    return render_template(template)
+
+    user_id = get_jwt_identity()
+    user = User.query.get(user_id)
+    if not user:
+        abort(404)
+
+    property_count = Property.query.filter_by(user_id=user_id).count()
+    saved_count = Favorite.query.filter_by(user_id=user_id).count()
+    alert_count = AlertPreference.query.filter_by(user_id=user_id).count()
+
+    return render_template(
+        template,
+        user=user,
+        property_count=property_count,
+        saved_count=saved_count,
+        alert_count=alert_count,
+        match_count=alert_count,
+    )
 
 # --- API Endpoints for Properties, Favorites, Evaluation, and Alerts ---
 @app.route("/api/properties", methods=["GET"])

--- a/templates/dashboard-agency.html
+++ b/templates/dashboard-agency.html
@@ -226,7 +226,7 @@
               <div class="card card-custom">
                 <div class="card-header">Agency Listings</div>
                 <div class="card-body">
-                  <p><span id="agency-property-count">15</span> active listings this month.</p>
+                  <p><span id="agency-property-count">{{ property_count }}</span> active listings this month.</p>
                   <div class="stats-box">
                     <h4>Views: <span id="view-count">150</span></h4>
                     <p>Total views this month</p>

--- a/templates/dashboard-buyer-renter.html
+++ b/templates/dashboard-buyer-renter.html
@@ -230,7 +230,7 @@
               <div class="card card-custom">
                 <div class="card-header">Favorites Overview</div>
                 <div class="card-body">
-                  <p>You have <span id="saved-count">4</span> saved properties.</p>
+                  <p>You have <span id="saved-count">{{ saved_count }}</span> saved properties.</p>
                   <div class="stats-box">
                     <h4>Recent Saves</h4>
                     <p>Check out your latest saved properties</p>
@@ -244,9 +244,9 @@
               <div class="card card-custom">
                 <div class="card-header">Alerts Overview</div>
                 <div class="card-body">
-                  <p>You have <span id="alert-count">2</span> active alerts.</p>
+                  <p>You have <span id="alert-count">{{ alert_count }}</span> active alerts.</p>
                   <div class="stats-box">
-                    <h4>Matches: <span id="match-count">2</span></h4>
+                    <h4>Matches: <span id="match-count">{{ match_count }}</span></h4>
                     <p>Properties matching your criteria</p>
                   </div>
                   <a href="/alerts" class="btn btn-primary">Manage Alerts</a>


### PR DESCRIPTION
## Summary
- enhance dashboard route to load current user and pass summary counts
- show property, favorite, and alert counts from Flask in dashboard templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684156a8a2248328bc52d673218417aa