### PR TITLE
Remove localStorage token references

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ pytest
 
 The tests use an in-memory SQLite database and cover basic authentication endpoints (signup and signin).
 
+## Authentication
+
+JWT access and refresh tokens are stored as **HttpOnly cookies**. Frontend scripts should not read or write these tokens with `localStorage`. Instead, include `credentials: 'include'` with each `fetch` request so the cookies are sent automatically. When CSRF protection is enabled, pass the `csrf_access_token` cookie value as the `X-CSRF-TOKEN` header on POST/PUT/DELETE requests.
+

--- a/templates/dashboard-agency.html
+++ b/templates/dashboard-agency.html
@@ -476,16 +476,28 @@
       const header = document.querySelector('header');
       header.classList.toggle('scrolled', window.scrollY > 50);
     });
+
+    function getCsrfToken() {
+      const match = document.cookie.match(/csrf_access_token=([^;]+)/);
+      return match ? decodeURIComponent(match[1]) : '';
+    }
     document.getElementById('logout-btn').addEventListener('click', async () => {
       try {
-        const response = await fetch('/logout', { method: 'POST' });
+        const response = await fetch('/logout', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+        });
         if (response.ok) { window.location.href = '/'; }
       } catch (error) { console.error('Logout Error:', error); }
     });
 
     async function loadAgencyProperties() {
       // Fetch and update listings count and stats
-      const response = await fetch('/api/agency/properties', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/agency/properties', {
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+      });
       const data = await response.json();
       document.getElementById('agency-property-count').textContent = data.count;
       document.getElementById('view-count').textContent = data.properties[0].views;
@@ -493,7 +505,10 @@
     }
 
     async function loadRequests() {
-      const response = await fetch('/api/requests', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/requests', {
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+      });
       const data = await response.json();
       document.getElementById('request-count').textContent = data.count;
       const requestsList = document.getElementById('requests-list');
@@ -506,7 +521,10 @@
     }
 
     async function loadAnalytics() {
-      const response = await fetch('/api/analytics', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/analytics', {
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+      });
       const data = await response.json();
       document.getElementById('conversion-rate').textContent = data.conversion_rate;
 
@@ -539,7 +557,8 @@
       const formData = new FormData(e.target);
       const response = await fetch('/api/agents/add', {
         method: 'POST',
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') },
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() },
         body: formData
       });
       if (response.ok) {
@@ -551,7 +570,10 @@
     });
 
     async function loadAgents() {
-      const response = await fetch('/api/agents', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/agents', {
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+      });
       const data = await response.json();
       const agentsTable = document.getElementById('agents-table');
       agentsTable.innerHTML = data.agents.map(agent => `
@@ -584,7 +606,8 @@
       const formData = new FormData(e.target);
       const response = await fetch('/api/agency/profile', {
         method: 'POST',
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') },
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() },
         body: formData
       });
       if (response.ok) { alert('Profile updated successfully!'); }

--- a/templates/dashboard-buyer-renter.html
+++ b/templates/dashboard-buyer-renter.html
@@ -391,11 +391,20 @@
     window.addEventListener('scroll', () => {
       document.querySelector('header').classList.toggle('scrolled', window.scrollY > 50);
     });
+
+    function getCsrfToken() {
+      const match = document.cookie.match(/csrf_access_token=([^;]+)/);
+      return match ? decodeURIComponent(match[1]) : '';
+    }
     
     // Logout functionality
     document.getElementById('logout-btn').addEventListener('click', async () => {
       try {
-        const response = await fetch('/logout', { method: 'POST' });
+        const response = await fetch('/logout', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+        });
         if (response.ok) {
           window.location.href = '/';
         }
@@ -406,8 +415,9 @@
     
     // Dynamic Data Loading Functions
     async function loadSavedProperties() {
-      const response = await fetch('/api/saved', { 
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } 
+      const response = await fetch('/api/saved', {
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() }
       });
       const data = await response.json();
       document.getElementById('saved-count').textContent = data.count || 4;
@@ -431,8 +441,9 @@
     }
     
     async function loadAlerts() {
-      const response = await fetch('/api/alerts', { 
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } 
+      const response = await fetch('/api/alerts', {
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() }
       });
       const data = await response.json();
       document.getElementById('alert-count').textContent = data.count || 2;
@@ -446,8 +457,9 @@
     }
     
     async function loadMarketSnapshot() {
-      const response = await fetch('/api/market-snapshot', { 
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } 
+      const response = await fetch('/api/market-snapshot', {
+        credentials: 'include',
+        headers: { 'X-CSRF-TOKEN': getCsrfToken() }
       });
       const data = await response.json();
       document.getElementById('avg-price').textContent = data.avg_price || '€1,350/m²';


### PR DESCRIPTION
## Summary
- remove use of `localStorage.getItem('token')`
- send cookies on dashboard requests
- document cookie-based authentication

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684156aa874083289addca271f264cfb