### PR TITLE
Remove local token use

### DIFF
--- a/templates/dashboard-agency.html
+++ b/templates/dashboard-agency.html
@@ -485,7 +485,7 @@
 
     async function loadAgencyProperties() {
       // Fetch and update listings count and stats
-      const response = await fetch('/api/agency/properties', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/agency/properties');
       const data = await response.json();
       document.getElementById('agency-property-count').textContent = data.count;
       document.getElementById('view-count').textContent = data.properties[0].views;
@@ -493,7 +493,7 @@
     }
 
     async function loadRequests() {
-      const response = await fetch('/api/requests', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/requests');
       const data = await response.json();
       document.getElementById('request-count').textContent = data.count;
       const requestsList = document.getElementById('requests-list');
@@ -506,7 +506,7 @@
     }
 
     async function loadAnalytics() {
-      const response = await fetch('/api/analytics', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/analytics');
       const data = await response.json();
       document.getElementById('conversion-rate').textContent = data.conversion_rate;
 
@@ -539,7 +539,6 @@
       const formData = new FormData(e.target);
       const response = await fetch('/api/agents/add', {
         method: 'POST',
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') },
         body: formData
       });
       if (response.ok) {
@@ -551,7 +550,7 @@
     });
 
     async function loadAgents() {
-      const response = await fetch('/api/agents', { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      const response = await fetch('/api/agents');
       const data = await response.json();
       const agentsTable = document.getElementById('agents-table');
       agentsTable.innerHTML = data.agents.map(agent => `
@@ -584,7 +583,6 @@
       const formData = new FormData(e.target);
       const response = await fetch('/api/agency/profile', {
         method: 'POST',
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') },
         body: formData
       });
       if (response.ok) { alert('Profile updated successfully!'); }

--- a/templates/dashboard-buyer-renter.html
+++ b/templates/dashboard-buyer-renter.html
@@ -406,9 +406,7 @@
     
     // Dynamic Data Loading Functions
     async function loadSavedProperties() {
-      const response = await fetch('/api/saved', { 
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } 
-      });
+      const response = await fetch('/api/saved');
       const data = await response.json();
       document.getElementById('saved-count').textContent = data.count || 4;
       const savedList = document.getElementById('saved-list');
@@ -431,9 +429,7 @@
     }
     
     async function loadAlerts() {
-      const response = await fetch('/api/alerts', { 
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } 
-      });
+      const response = await fetch('/api/alerts');
       const data = await response.json();
       document.getElementById('alert-count').textContent = data.count || 2;
       document.getElementById('match-count').textContent = data.alerts.length || 2;
@@ -446,9 +442,7 @@
     }
     
     async function loadMarketSnapshot() {
-      const response = await fetch('/api/market-snapshot', { 
-        headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } 
-      });
+      const response = await fetch('/api/market-snapshot');
       const data = await response.json();
       document.getElementById('avg-price').textContent = data.avg_price || '€1,350/m²';
       // Optionally, update the second market snapshot in the Market tab


### PR DESCRIPTION
## Summary
- drop Authorization header using nonexistent token

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684156acaa0883288f877c7fccc965cf