### PR TITLE
Remove tracked env file and add example

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-SECRET_KEY=your-local-secret-key
-JWT_SECRET_KEY=your-local-jwt-key
-DATABASE_URL=sqlite:///site.db  # Use SQLite locally

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SECRET_KEY=your-secret-key
+JWT_SECRET_KEY=your-jwt-secret
+DATABASE_URL=sqlite:///properties.db
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_MAPS_API_KEY=your-google-maps-key
+PORT=5000

--- a/.gitignore
+++ b/.gitignore
@@ -119,8 +119,9 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
-# Environments
+# Ignore local environment variable files
 .env
+# Environments
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is a simple Flask backend for a real estate website. The applicatio
    - `GOOGLE_MAPS_API_KEY` – API key for Google Maps (required for map features).
    - `PORT` – Port for the development server (default: `5000`).
 
-You can create a `.env` file or export these variables in your shell before running the server.
+Copy `.env.example` to `.env` and update the values, or export these variables in your shell before running the server.
 
 ## Running the Server
 


### PR DESCRIPTION
## Summary
- remove the committed `.env`
- add `.env.example` with placeholder values
- document `.env.example` in README
- clarify `.env` line in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684364185d388328bd95505b626ce0a0