### PR TITLE
Remove automatic DB init

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,9 +136,6 @@ class Offer(db.Model):
     status = db.Column(db.String(20), default="pending")
     created_at = db.Column(db.DateTime, default=db.func.current_timestamp())
 
-with app.app_context():
-    db.create_all()
-
 # --- Authentication Endpoints ---
 @app.route("/signin", methods=["POST"])
 @limiter.limit("10 per minute")

--- a/init_db.py
+++ b/init_db.py
@@ -1,7 +1,21 @@
+import argparse
 from app import app, db
 
-if __name__ == "__main__":
+
+def init_db(drop=False):
     with app.app_context():
-        db.drop_all()
+        if drop:
+            db.drop_all()
         db.create_all()
         print("Database tables created.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Initialize the database.")
+    parser.add_argument(
+        "--drop",
+        action="store_true",
+        help="Drop existing tables before creating new ones.",
+    )
+    args = parser.parse_args()
+    init_db(drop=args.drop)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
-from app import app
+from app import app, db
 
 if __name__ == "__main__":
     # For local development only
     import os
+    if os.getenv("INIT_DB"):
+        with app.app_context():
+            db.create_all()
     port = int(os.getenv("PORT", 5000))  # Use PORT env var if set, else default to 5000
     app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
## Summary
- avoid creating tables on import
- allow initializing database via `init_db.py`
- add optional INIT_DB environment variable to `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684365cf8b808328b32b223d9d28a02c