### PR TITLE
Improve global error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -807,8 +807,9 @@ def market_snapshot():
 # --- Global Error Handler ---
 @app.errorhandler(Exception)
 def handle_exception(e):
-    logging.error(f"Unhandled exception: {str(e)}")
-    return jsonify({"message": f"Server error: {str(e)}"}), 500
+    """Log unexpected exceptions and return a generic error message."""
+    logging.exception(f"Unhandled exception: {e}")
+    return jsonify({"message": "Internal server error"}), 500
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", 5000))

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,37 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+# Configure environment for tests
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_generic_error_message(client):
+    @app.route("/trigger-error")
+    def trigger_error():
+        raise ValueError("Sensitive details")
+
+    resp = client.get("/trigger-error")
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data["message"] == "Internal server error"
+    assert "Sensitive details" not in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- log exceptions with stack traces
- return generic error responses via `handle_exception`
- add tests to ensure sensitive info isn't leaked

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684367c3d7888328b9337ff722e88996