### PR TITLE
Add error branch tests

### DIFF
--- a/tests/test_error_branches.py
+++ b/tests/test_error_branches.py
@@ -1,0 +1,47 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+# Configure environment for tests
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_error", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def signup(client, email="test@example.com", password="password123"):
+    client.post(
+        "/signup",
+        json={
+            "name": "Test",
+            "email": email,
+            "password": password,
+            "user_type": "Buyer/Renter",
+        },
+    )
+
+
+def test_invalid_login_returns_401(client):
+    signup(client)
+    resp = client.post(
+        "/signin",
+        json={"email": "test@example.com", "password": "wrong"},
+    )
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Invalid credentials!"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -69,6 +69,8 @@ def test_property_creation_requires_auth(client):
     }
     resp = client.post("/api/properties", data=data)
     assert resp.status_code == 401
+    # flask-jwt-extended returns a default 'msg' key for missing auth header
+    assert resp.get_json()["msg"] == "Missing Authorization Header"
 
 
 def test_create_agent_and_retrieve(client):


### PR DESCRIPTION
## Summary
- test invalid login returns 401 in new test_error_branches module
- verify unauthorized property creation message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68436b28f99c8328bee8ddd61a1b52bb