### PR TITLE
Add contact page route and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -424,6 +424,11 @@ def agents_page():
     """List real estate agents."""
     return render_template("agents.html")
 
+@app.route("/contact")
+def contact_page():
+    """Render the contact page."""
+    return render_template("contact.html")
+
 @app.route("/dashboard/<role>")
 @jwt_required()
 def dashboard(role):

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Get in touch with Albania Properties for help with buying, selling or renting." />
+  <title>Contact Albania Properties</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --primary-color: #1a73e8;
+      --secondary-color: #2d3748;
+      --accent-color: #00c4b4;
+      --background-light: #f9fafb;
+      --text-dark: #1f2a44;
+      --text-light: #fff;
+      --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.08);
+    }
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: var(--background-light);
+      color: var(--text-dark);
+      line-height: 1.6;
+    }
+    header {
+      background: #fff;
+      box-shadow: var(--shadow-sm);
+    }
+    .navbar-brand {
+      font-weight: 600;
+      color: var(--text-dark);
+    }
+    .section-content {
+      padding-top: 6rem;
+      padding-bottom: 4rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="navbar navbar-expand-lg">
+      <div class="container">
+        <a class="navbar-brand" href="/">
+          <i class="fas fa-home"></i> Albania Properties
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+          <ul class="navbar-nav">
+            <li class="nav-item"><a class="nav-link" href="/properties?purpose=buy">Buy</a></li>
+            <li class="nav-item"><a class="nav-link" href="/properties?purpose=rent">Rent</a></li>
+            <li class="nav-item"><a class="nav-link" href="/sell">Sell</a></li>
+            <li class="nav-item"><a class="nav-link" href="/agents">Find an Agent</a></li>
+            <li class="nav-item"><a class="nav-link" href="/signin">Sign In</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <main id="main-content">
+    <section class="section-content container">
+      <h1 class="mb-4">Contact Us</h1>
+      <p class="lead">We're here to answer your real estate questions.</p>
+      <p>Email us at <a href="mailto:info@albania-properties.com">info@albania-properties.com</a> or call <a href="tel:+355000000">+355 000 000</a>.</p>
+    </section>
+  </main>
+
+  <footer class="text-center py-4">
+    <small>&copy; 2025 Albania Properties</small>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/tests/test_contact_route.py
+++ b/tests/test_contact_route.py
@@ -1,0 +1,30 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_contact", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_contact_page(client):
+    resp = client.get("/contact")
+    assert resp.status_code == 200
+    assert b"Contact Us" in resp.data


### PR DESCRIPTION
## Summary
- add new contact.html template with basic branding
- expose `/contact` route in the Flask app
- verify the contact route works in new test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68436ea525108328bbe632baecd7f12b