### PR TITLE
Add market trends page

### DIFF
--- a/app.py
+++ b/app.py
@@ -394,6 +394,11 @@ def market_page():
     """Render the market statistics page."""
     return render_template("market.html")
 
+@app.route("/market-trends")
+def market_trends_page():
+    """Show in-depth market trends."""
+    return render_template("market-trends.html")
+
 @app.route("/alerts")
 def alerts_page():
     """Show the alerts management page."""

--- a/templates/market-trends.html
+++ b/templates/market-trends.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Market Trends</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --primary-color: #1a73e8;
+      --background-light: #f9fafb;
+      --text-dark: #1f2a44;
+      --shadow-sm: 0 2px 10px rgba(0,0,0,0.08);
+    }
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: var(--background-light);
+      color: var(--text-dark);
+      line-height: 1.6;
+    }
+    header {
+      background: #fff;
+      box-shadow: var(--shadow-sm);
+    }
+    .navbar-brand {
+      font-weight: 600;
+      color: var(--text-dark);
+    }
+    .section-content {
+      padding-top: 6rem;
+      padding-bottom: 4rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="navbar navbar-expand-lg">
+      <div class="container">
+        <a class="navbar-brand" href="/">
+          <i class="fas fa-home"></i> Albania Properties
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+          <ul class="navbar-nav">
+            <li class="nav-item"><a class="nav-link" href="/properties?purpose=buy">Buy</a></li>
+            <li class="nav-item"><a class="nav-link" href="/properties?purpose=rent">Rent</a></li>
+            <li class="nav-item"><a class="nav-link" href="/sell">Sell</a></li>
+            <li class="nav-item"><a class="nav-link" href="/agents">Find an Agent</a></li>
+            <li class="nav-item"><a class="nav-link" href="/signin">Sign In</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <main id="main-content">
+    <section class="section-content container">
+      <h1 class="mb-4">Market Trends</h1>
+      <p class="lead">Stay informed with the latest real estate market trends across Albania.</p>
+      <p>We analyze pricing data, supply and demand, and regional differences to help you make the best decision when buying or selling property.</p>
+    </section>
+  </main>
+
+  <footer class="text-center py-4">
+    <small>&copy; 2025 Albania Properties</small>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new market trends page template
- support new `/market-trends` route in the Flask app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6843709fc5188328ac9b347c63de672a