### PR TITLE
Add reset password page

### DIFF
--- a/app.py
+++ b/app.py
@@ -374,6 +374,11 @@ def signin_page():
     """Render the sign in HTML page."""
     return render_template("signin.html")
 
+@app.route("/reset-password")
+def reset_password_page():
+    """Render the password reset form."""
+    return render_template("reset-password.html")
+
 @app.route("/for-owners")
 def for_owners():
     """Return the page describing services for property owners."""

--- a/templates/reset-password.html
+++ b/templates/reset-password.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reset Password</title>
+</head>
+<body>
+  <h1>Reset Password</h1>
+  <form method="post" action="/reset-password">
+    <label for="email">Email:</label>
+    <input type="email" id="email" name="email" required><br>
+    <label for="password">New Password:</label>
+    <input type="password" id="password" name="password" required><br>
+    <button type="submit">Reset Password</button>
+  </form>
+</body>
+</html>

--- a/tests/test_reset_password_route.py
+++ b/tests/test_reset_password_route.py
@@ -1,0 +1,30 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_reset_password", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_reset_password_page(client):
+    resp = client.get("/reset-password")
+    assert resp.status_code == 200
+    assert b"Reset Password" in resp.data


### PR DESCRIPTION
## Summary
- add `reset-password.html` template
- add `/reset-password` route for password reset page
- test the new route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684371c0883c8328a18f8f28f2b2752b