### PR TITLE
Add join-as-agent route

### DIFF
--- a/app.py
+++ b/app.py
@@ -439,6 +439,11 @@ def agents_page():
     """List real estate agents."""
     return render_template("agents.html")
 
+@app.route("/join-as-agent")
+def join_as_agent_page():
+    """Render the join as agent page."""
+    return render_template("join-as-agent.html")
+
 @app.route("/contact")
 def contact_page():
     """Render the contact page."""

--- a/templates/join-as-agent.html
+++ b/templates/join-as-agent.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Join as an Agent</title>
+</head>
+<body>
+  <h1>Join as an Agent</h1>
+  <p>Fill out the form below to join our team of professional agents.</p>
+</body>
+</html>

--- a/tests/test_join_as_agent_route.py
+++ b/tests/test_join_as_agent_route.py
@@ -1,0 +1,30 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_join_as_agent", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_join_as_agent_page(client):
+    resp = client.get("/join-as-agent")
+    assert resp.status_code == 200
+    assert b"Join as an Agent" in resp.data


### PR DESCRIPTION
## Summary
- create `templates/join-as-agent.html` with placeholder text
- provide `/join-as-agent` route in `app.py`
- test new route

## Testing
- `pytest -q tests/test_join_as_agent_route.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843726f17348328b17ba0d92cde4a55