### PR TITLE
Add diy-sell and instant-offer pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -394,6 +394,16 @@ def sell_page():
     """Render the selling information page."""
     return render_template("sell.html")
 
+@app.route("/diy-sell")
+def diy_sell_page():
+    """Show resources for selling a property yourself."""
+    return render_template("diy-sell.html")
+
+@app.route("/instant-offer")
+def instant_offer_page():
+    """Provide a page for getting an instant offer."""
+    return render_template("instant-offer.html")
+
 @app.route("/market")
 def market_page():
     """Render the market statistics page."""

--- a/templates/diy-sell.html
+++ b/templates/diy-sell.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DIY Sell Your Property</title>
+</head>
+<body>
+  <h1>DIY Sell Your Property</h1>
+  <p>Tools and tips for selling your property yourself.</p>
+</body>
+</html>

--- a/templates/instant-offer.html
+++ b/templates/instant-offer.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Instant Offer</title>
+</head>
+<body>
+  <h1>Get an Instant Offer</h1>
+  <p>Receive a quick cash offer for your property.</p>
+</body>
+</html>

--- a/tests/test_diy_sell_route.py
+++ b/tests/test_diy_sell_route.py
@@ -1,0 +1,30 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_diy_sell", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_diy_sell_page(client):
+    resp = client.get("/diy-sell")
+    assert resp.status_code == 200
+    assert b"DIY Sell Your Property" in resp.data

--- a/tests/test_instant_offer_route.py
+++ b/tests/test_instant_offer_route.py
@@ -1,0 +1,30 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_instant_offer", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_instant_offer_page(client):
+    resp = client.get("/instant-offer")
+    assert resp.status_code == 200
+    assert b"Get an Instant Offer" in resp.data


### PR DESCRIPTION
## Summary
- create DIY sell and instant offer templates
- add routes to serve the new templates
- test new routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68437328de84832899c1893426aa08d0