### PR TITLE
Add private agent page

### DIFF
--- a/app.py
+++ b/app.py
@@ -454,6 +454,12 @@ def join_as_agent_page():
     """Render the join as agent page."""
     return render_template("join-as-agent.html")
 
+
+@app.route("/list/private-agent")
+def private_agent_page():
+    """Render the private agent listing page."""
+    return render_template("private-agent.html")
+
 @app.route("/contact")
 def contact_page():
     """Render the contact page."""

--- a/templates/private-agent.html
+++ b/templates/private-agent.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Private Agent Listing</title>
+</head>
+<body>
+  <h1>Private Agent Listing</h1>
+  <p>Browse exclusive listings from our private agents.</p>
+</body>
+</html>

--- a/tests/test_private_agent_route.py
+++ b/tests/test_private_agent_route.py
@@ -1,0 +1,30 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_private_agent", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_private_agent_page(client):
+    resp = client.get("/list/private-agent")
+    assert resp.status_code == 200
+    assert b"Private Agent Listing" in resp.data


### PR DESCRIPTION
## Summary
- add `private-agent.html`
- serve new page from `/list/private-agent`
- test the route

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684373e161c083288cfb000e4cf6507f