### PR TITLE
Add detail routes

### DIFF
--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ agent.name }} | Albania Properties</title>
+</head>
+<body>
+  <h1>{{ agent.name }}</h1>
+  <p>Agency: {{ agent.agency }}</p>
+  <p>Email: {{ agent.email }}</p>
+  <p>Phone: {{ agent.phone }}</p>
+  {% if agent.photo_url %}
+  <img src="{{ agent.photo_url }}" alt="{{ agent.name }}" />
+  {% endif %}
+</body>
+</html>

--- a/templates/property_detail.html
+++ b/templates/property_detail.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ property.title }} | Albania Properties</title>
+</head>
+<body>
+  <h1>{{ property.title }}</h1>
+  <p>{{ property.location }}</p>
+  <p>Price: {{ property.price }}</p>
+  <p>{{ property.beds }} beds, {{ property.baths }} baths</p>
+  {% if property.image_url %}
+  <img src="{{ property.image_url }}" alt="{{ property.title }}" />
+  {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement slugify helper
- add `/property/<slug>` and `/agent/<slug>` dynamic routes
- create minimal templates for property and agent details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684374818b9483289a519412e326cdff