### PR TITLE
Add admin role and access control

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Admin Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container">
+      <a class="navbar-brand" href="/">Real Estate</a>
+      <div class="collapse navbar-collapse">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" id="logout-btn">Logout</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <div class="container py-5">
+    <h1 class="mb-4">Admin Dashboard</h1>
+    <h2 class="h4">Users</h2>
+    <ul class="list-group mb-4">
+      {% for u in users %}
+        <li class="list-group-item">{{ u.email }} - {{ u.user_type }}</li>
+      {% endfor %}
+    </ul>
+    <h2 class="h4">Properties</h2>
+    <ul class="list-group mb-4">
+      {% for p in properties %}
+        <li class="list-group-item">{{ p.title }} - {{ p.location }}</li>
+      {% endfor %}
+    </ul>
+    <h2 class="h4">Analytics</h2>
+    <p>Total users: {{ users|length }}</p>
+    <p>Total properties: {{ properties|length }}</p>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    function getCsrfToken() {
+      const match = document.cookie.match(/csrf_access_token=([^;]+)/);
+      return match ? decodeURIComponent(match[1]) : '';
+    }
+    document.getElementById('logout-btn').addEventListener('click', async () => {
+      const resp = await fetch('/logout', {method: 'POST', credentials: 'include', headers: {'X-CSRF-TOKEN': getCsrfToken()}});
+      if (resp.ok) window.location.href = '/';
+    });
+  </script>
+</body>
+</html>

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -1,0 +1,82 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["JWT_SECRET_KEY"] = "test-secret"
+
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app_admin", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+app = app_module.app
+db = app_module.db
+User = app_module.User
+
+@pytest.fixture()
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+def create_admin(client):
+    client.post(
+        "/signup",
+        json={
+            "name": "Admin",
+            "email": "admin@example.com",
+            "password": "pass",
+            "user_type": "Landlord",
+        },
+    )
+    with app.app_context():
+        user = User.query.filter_by(email="admin@example.com").first()
+        user.is_admin = True
+        db.session.commit()
+
+
+def login(client, email="admin@example.com", password="pass"):
+    return client.post("/signin", json={"email": email, "password": password})
+
+
+def test_admin_route_requires_admin(client):
+    create_admin(client)
+    login(client)
+    resp = client.get("/admin")
+    assert resp.status_code == 200
+
+    # normal user should be forbidden
+    client.post(
+        "/signup",
+        json={
+            "name": "User",
+            "email": "user@example.com",
+            "password": "pass",
+            "user_type": "Landlord",
+        },
+    )
+    client.post("/signin", json={"email": "user@example.com", "password": "pass"})
+    resp = client.get("/admin")
+    assert resp.status_code == 403
+
+
+def test_dashboard_role_mismatch(client):
+    client.post(
+        "/signup",
+        json={
+            "name": "Landlord",
+            "email": "land@example.com",
+            "password": "pass",
+            "user_type": "Landlord",
+        },
+    )
+    client.post("/signin", json={"email": "land@example.com", "password": "pass"})
+    resp = client.get("/dashboard/landlord")
+    assert resp.status_code == 200
+    resp = client.get("/dashboard/buyer-renter")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add `is_admin` flag to `User`
- block admin registration in signup
- restrict dashboard to matching role
- implement `/admin` route with JWT protection
- build simple admin dashboard template
- add tests for admin access and dashboard role checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68440cf86db08328b37911b3973da670