### PR TITLE
Add styled admin dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -561,11 +561,20 @@ def admin_panel():
         abort(403)
     users = User.query.all()
     properties = Property.query.all()
+    user_count = len(users)
+    property_count = len(properties)
+    request_count = EvaluationRequest.query.count()
+    agent_count = Agent.query.count()
+
     return render_template(
         "admin.html",
         users=users,
         properties=properties,
         user=user,
+        user_count=user_count,
+        property_count=property_count,
+        request_count=request_count,
+        agent_count=agent_count,
     )
 
 # --- API Endpoints for Properties, Favorites, Evaluation, and Alerts ---

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -1,0 +1,136 @@
+:root {
+  --primary-color: #1a73e8;
+  --background-light: #f9fafb;
+  --text-dark: #1f2a44;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background-light);
+  color: var(--text-dark);
+  line-height: 1.6;
+  transition: background 0.3s, color 0.3s;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 230px;
+  height: 100vh;
+  background: #fff;
+  border-right: 1px solid #ddd;
+  padding: 20px 15px;
+  overflow-y: auto;
+}
+
+.sidebar h2 {
+  font-size: 1.4rem;
+  margin-bottom: 20px;
+  color: var(--primary-color);
+}
+
+.sidebar a {
+  display: block;
+  padding: 10px 15px;
+  color: var(--text-dark);
+  border-radius: 6px;
+  margin-bottom: 10px;
+  transition: background 0.3s;
+}
+
+.sidebar a:hover,
+.sidebar a.active {
+  background: #e9ecef;
+  color: var(--primary-color);
+}
+
+.top-header {
+  position: fixed;
+  top: 0;
+  left: 230px;
+  right: 0;
+  height: 60px;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  z-index: 100;
+}
+
+.main-content {
+  margin-left: 230px;
+  padding: 80px 20px 40px;
+  background: #f4f7f9;
+  min-height: calc(100vh - 60px);
+}
+
+.panel {
+  background: rgba(255,255,255,0.6);
+  border: 1px solid rgba(255,255,255,0.3);
+  backdrop-filter: blur(10px);
+  border-radius: 15px;
+  padding: 30px;
+  margin-bottom: 30px;
+  box-shadow: 0 8px 32px rgba(31,38,135,0.1);
+}
+
+.dark-mode {
+  background: #1e1e2f;
+  color: #f0f0f0;
+}
+
+.dark-mode .sidebar {
+  background: linear-gradient(180deg, #14142b, #1e1e2f);
+  border-right: 1px solid #333;
+}
+
+.dark-mode .sidebar a {
+  color: #adb5bd;
+}
+
+.dark-mode .sidebar a:hover,
+.dark-mode .sidebar a.active {
+  background: rgba(52,58,64,0.8);
+  color: #fff;
+}
+
+.dark-mode .top-header {
+  background: #14142b;
+  border-bottom: 1px solid #333;
+}
+
+.dark-mode .main-content {
+  background: #1e1e2f;
+}
+
+.dark-mode .panel {
+  background: rgba(0,0,0,0.4);
+  border: 1px solid rgba(0,0,0,0.3);
+}
+
+.toggle-dark {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #00bcd4;
+  border: none;
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  color: #1e1e2f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+  z-index: 1000;
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -5,36 +5,99 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Admin Dashboard</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container">
-      <a class="navbar-brand" href="/">Real Estate</a>
-      <div class="collapse navbar-collapse">
-        <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link" id="logout-btn">Logout</a></li>
+  <nav class="sidebar">
+    <h2>Admin</h2>
+    <a href="#users" class="sidebar-link">Users</a>
+    <a href="#properties" class="sidebar-link">Properties</a>
+    <a href="#requests" class="sidebar-link">Requests</a>
+    <a href="#agents" class="sidebar-link">Agents</a>
+    <a href="#analytics" class="sidebar-link">Analytics</a>
+    <a href="#settings" class="sidebar-link">Settings</a>
+  </nav>
+
+  <div class="top-header">
+    <div class="header-left">Real Estate Admin</div>
+    <div class="header-right">
+      <button class="btn btn-sm btn-outline-secondary me-3" id="darkModeToggle">
+        <i class="fas fa-moon"></i>
+      </button>
+      <div class="dropdown d-inline">
+        <a href="#" class="d-flex align-items-center text-decoration-none dropdown-toggle" data-bs-toggle="dropdown">
+          <i class="fas fa-user-circle fa-lg me-1"></i> {{ user.name }}
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" id="logout-btn">Logout</a></li>
         </ul>
       </div>
     </div>
-  </nav>
-  <div class="container py-5">
-    <h1 class="mb-4">Admin Dashboard</h1>
-    <h2 class="h4">Users</h2>
-    <ul class="list-group mb-4">
-      {% for u in users %}
-        <li class="list-group-item">{{ u.email }} - {{ u.user_type }}</li>
-      {% endfor %}
-    </ul>
-    <h2 class="h4">Properties</h2>
-    <ul class="list-group mb-4">
-      {% for p in properties %}
-        <li class="list-group-item">{{ p.title }} - {{ p.location }}</li>
-      {% endfor %}
-    </ul>
-    <h2 class="h4">Analytics</h2>
-    <p>Total users: {{ users|length }}</p>
-    <p>Total properties: {{ properties|length }}</p>
   </div>
+
+  <div class="main-content">
+    <div id="users" class="panel">
+      <h2 class="mb-3">Users</h2>
+      <div class="table-responsive">
+        <table class="table table-hover align-middle">
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Type</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for u in users %}
+            <tr>
+              <td>{{ u.email }}</td>
+              <td>{{ u.user_type }}</td>
+              <td>
+                <a href="#" class="text-primary"><i class="fas fa-edit"></i></a>
+                <a href="#" class="text-danger ms-2"><i class="fas fa-trash-alt"></i></a>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div id="properties" class="panel">
+      <h2 class="mb-3">Properties</h2>
+      <div class="table-responsive">
+        <table class="table table-hover align-middle">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Location</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for p in properties %}
+            <tr>
+              <td>{{ p.title }}</td>
+              <td>{{ p.location }}</td>
+              <td>
+                <a href="#" class="text-primary"><i class="fas fa-edit"></i></a>
+                <a href="#" class="text-danger ms-2"><i class="fas fa-trash-alt"></i></a>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div id="analytics" class="panel">
+      <h2 class="mb-3">Analytics</h2>
+      <canvas id="analyticsChart" height="80"></canvas>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>
     function getCsrfToken() {
@@ -42,8 +105,29 @@
       return match ? decodeURIComponent(match[1]) : '';
     }
     document.getElementById('logout-btn').addEventListener('click', async () => {
-      const resp = await fetch('/logout', {method: 'POST', credentials: 'include', headers: {'X-CSRF-TOKEN': getCsrfToken()}});
+      const resp = await fetch('/logout', {method:'POST',credentials:'include',headers:{'X-CSRF-TOKEN':getCsrfToken()}});
       if (resp.ok) window.location.href = '/';
+    });
+    document.getElementById('darkModeToggle').addEventListener('click', function() {
+      document.body.classList.toggle('dark-mode');
+      const icon = this.querySelector('i');
+      icon.classList.toggle('fa-moon');
+      icon.classList.toggle('fa-sun');
+    });
+    new Chart(document.getElementById('analyticsChart'), {
+      type: 'bar',
+      data: {
+        labels: ['Users', 'Properties'],
+        datasets: [{
+          backgroundColor: ['#1a73e8', '#00c4b4'],
+          data: [{{ user_count }}, {{ property_count }}]
+        }]
+      },
+      options: {
+        plugins: { legend: { display: false } },
+        responsive: true,
+        scales: { y: { beginAtZero: true } }
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- restyle `admin.html` with sidebar navigation, user/profile tables and Chart.js analytics
- add new stylesheet `static/css/admin.css`
- enhance `/admin` route with counts for analytics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848a73518188328bd210da5e1737fc4