### PR TITLE
Fix HTTPException handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import logging
 from datetime import timedelta
 
 from flask import Flask, jsonify, request, render_template, make_response, abort
+from werkzeug.exceptions import HTTPException
 import re
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
@@ -988,7 +989,9 @@ def market_snapshot():
 @app.errorhandler(Exception)
 def handle_exception(e):
     """Log unexpected exceptions and return a generic error message."""
-    logging.exception(f"Unhandled exception: {e}")
+    if isinstance(e, HTTPException):
+        return e
+    logging.exception("Unhandled exception: %s", e)
     return jsonify({"message": "Internal server error"}), 500
 
 if __name__ == "__main__":

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -35,3 +35,13 @@ def test_generic_error_message(client):
     data = resp.get_json()
     assert data["message"] == "Internal server error"
     assert "Sensitive details" not in resp.get_data(as_text=True)
+
+
+def test_page_not_found_returns_404(client):
+    resp = client.get("/nonexistent")
+    assert resp.status_code == 404
+
+
+def test_resource_not_found_returns_404(client):
+    resp = client.get("/api/agents/999")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- handle HTTPException separately in `handle_exception`
- add tests for missing pages and resources returning 404

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement blinker==1.9.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848adc9bc6c8328b85d664bdee93aee