### PR TITLE
Allow overriding JWT cookie secure flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ JWT_SECRET_KEY=your-jwt-secret
 DATABASE_URL=sqlite:///properties.db
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_MAPS_API_KEY=your-google-maps-key
+JWT_COOKIE_SECURE=True
 PORT=5000

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project is a simple Flask backend for a real estate website. The applicatio
    - `JWT_SECRET_KEY` – Secret key used to sign JWT tokens.
    - `GOOGLE_CLIENT_ID` – Client ID for Google OAuth (optional).
    - `GOOGLE_MAPS_API_KEY` – API key for Google Maps (required for map features).
+   - `JWT_COOKIE_SECURE` – Set to `True` to transmit JWT cookies over HTTPS only (default `True`).
    - `PORT` – Port for the development server (default: `5000`).
 
 Copy `.env.example` to `.env` and update the values, or export these variables in your shell before running the server.

--- a/app.py
+++ b/app.py
@@ -36,7 +36,8 @@ app.config['JWT_SECRET_KEY'] = config('JWT_SECRET_KEY', default='default_secret_
 app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(hours=1)
 app.config['JWT_REFRESH_TOKEN_EXPIRES'] = timedelta(days=30)
 app.config['JWT_TOKEN_LOCATION'] = ['cookies']
-app.config['JWT_COOKIE_SECURE'] = True
+jwt_cookie_secure = config('JWT_COOKIE_SECURE', default='True')
+app.config['JWT_COOKIE_SECURE'] = str(jwt_cookie_secure).lower() in ['true', '1', 'yes']
 app.config['JWT_COOKIE_CSRF_PROTECT'] = True
 app.config['GOOGLE_MAPS_API_KEY'] = config('GOOGLE_MAPS_API_KEY', default='')
 


### PR DESCRIPTION
## Summary
- make JWT cookie security overridable by `JWT_COOKIE_SECURE`
- document `JWT_COOKIE_SECURE`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848ae7717948328aef630888f470d58