### PR TITLE
Add CSRF cookie verification

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -40,6 +40,7 @@ def test_signup_and_signin(client):
     )
     assert resp.status_code == 201
     assert resp.get_json()["message"] == "Signed up successfully"
+    assert "csrf_token" in resp.get_json()
 
     resp = client.post(
         "/signin",
@@ -47,4 +48,5 @@ def test_signup_and_signin(client):
     )
     assert resp.status_code == 200
     assert resp.get_json()["message"] == "Signed in successfully"
+    assert "csrf_token" in resp.get_json()
 

--- a/tests/test_new_endpoints.py
+++ b/tests/test_new_endpoints.py
@@ -34,14 +34,15 @@ def authenticate(client):
             "user_type": "Agency",
         },
     )
-    client.post(
+    resp = client.post(
         "/signin",
         json={"email": "agency@example.com", "password": "password123"},
     )
+    return resp.get_json()["csrf_token"]
 
 
 def test_new_endpoints_authenticated(client):
-    authenticate(client)
+    csrf = authenticate(client)
 
     resp = client.get("/api/analytics")
     assert resp.status_code == 200
@@ -49,10 +50,10 @@ def test_new_endpoints_authenticated(client):
     resp = client.get("/api/requests")
     assert resp.status_code == 200
 
-    resp = client.post("/api/agency/profile", json={"name": "New Name"})
+    resp = client.post("/api/agency/profile", json={"name": "New Name"}, headers={"X-CSRF-TOKEN": csrf})
     assert resp.status_code == 200
 
-    resp = client.post("/api/agents/add", json={"name": "Agent X"})
+    resp = client.post("/api/agents/add", json={"name": "Agent X"}, headers={"X-CSRF-TOKEN": csrf})
     assert resp.status_code == 201
 
     resp = client.get("/api/market-snapshot")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -31,10 +31,11 @@ def signup_and_login(client, email="user@example.com", password="password"):
     )
     resp = client.post("/signin", json={"email": email, "password": password})
     assert resp.status_code == 200
+    return resp.get_json()["csrf_token"]
 
 
 def test_create_and_get_property(client):
-    signup_and_login(client)
+    csrf = signup_and_login(client)
     data = {
         "title": "Test Home",
         "location": "Test City",
@@ -45,7 +46,7 @@ def test_create_and_get_property(client):
         "baths": "1",
         "size": "80",
     }
-    resp = client.post("/api/properties", data=data)
+    resp = client.post("/api/properties", data=data, headers={"X-CSRF-TOKEN": csrf})
     assert resp.status_code == 201
     prop_id = resp.get_json()["id"]
     assert prop_id is not None
@@ -74,9 +75,9 @@ def test_property_creation_requires_auth(client):
 
 
 def test_create_agent_and_retrieve(client):
-    signup_and_login(client)
+    csrf = signup_and_login(client)
     agent_data = {"name": "Agent Smith", "email": "a@example.com"}
-    resp = client.post("/api/agents", json=agent_data)
+    resp = client.post("/api/agents", json=agent_data, headers={"X-CSRF-TOKEN": csrf})
     assert resp.status_code == 201
     agent_id = resp.get_json()["id"]
     assert agent_id is not None
@@ -88,8 +89,8 @@ def test_create_agent_and_retrieve(client):
 
 
 def test_create_agent_missing_name(client):
-    signup_and_login(client)
-    resp = client.post("/api/agents", json={"email": "a@example.com"})
+    csrf = signup_and_login(client)
+    resp = client.post("/api/agents", json={"email": "a@example.com"}, headers={"X-CSRF-TOKEN": csrf})
     assert resp.status_code == 500
 
 


### PR DESCRIPTION
## Summary
- return CSRF tokens when logging in or signing up
- verify CSRF token on state-changing endpoints
- adapt tests for CSRF token usage

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement blinker==1.9.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848af2aee4483289c9f0ec4c9bd18e2