### PR TITLE
Refactor tests to use shared fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+# Set up environment variables for tests
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+# Dynamically import the app module from the repository
+app_path = Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("test_app", app_path)
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+
+# Expose commonly used objects
+app = app_module.app
+db = app_module.db
+User = getattr(app_module, "User", None)
+
+
+@pytest.fixture()
+def client():
+    """Provide a Flask test client with a fresh database."""
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()

--- a/tests/test_about_route.py
+++ b/tests/test_about_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_about", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_about_page(client):

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -1,28 +1,5 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_admin", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-User = app_module.User
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
+from conftest import app, db, User
 
 def create_admin(client):
     client.post(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,31 +1,4 @@
-import os
 import pytest
-import importlib.util
-from pathlib import Path
-
-# Configure environment for tests
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-# Import the app module from the repository directly to avoid conflicts with any
-# installed packages named "app".
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-User = app_module.User
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_signup_and_signin(client):

--- a/tests/test_contact_route.py
+++ b/tests/test_contact_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_contact", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_contact_page(client):

--- a/tests/test_diy_sell_route.py
+++ b/tests/test_diy_sell_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_diy_sell", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_diy_sell_page(client):

--- a/tests/test_error_branches.py
+++ b/tests/test_error_branches.py
@@ -1,28 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-# Configure environment for tests
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_error", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def signup(client, email="test@example.com", password="password123"):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,28 +1,5 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-# Configure environment for tests
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
+from conftest import app
 
 
 def test_generic_error_message(client):

--- a/tests/test_instant_offer_route.py
+++ b/tests/test_instant_offer_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_instant_offer", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_instant_offer_page(client):

--- a/tests/test_invalid_requests.py
+++ b/tests/test_invalid_requests.py
@@ -1,29 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-# Configure environment for tests
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_invalid", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def signup_and_login(client, email="user@example.com", password="password"):

--- a/tests/test_join_as_agent_route.py
+++ b/tests/test_join_as_agent_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_join_as_agent", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_join_as_agent_page(client):

--- a/tests/test_mortgage_route.py
+++ b/tests/test_mortgage_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_mortgage", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_mortgage_page(client):

--- a/tests/test_new_endpoints.py
+++ b/tests/test_new_endpoints.py
@@ -1,28 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-# Configure environment for tests
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 def authenticate(client):
     client.post(

--- a/tests/test_private_agent_route.py
+++ b/tests/test_private_agent_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_private_agent", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_private_agent_page(client):

--- a/tests/test_reset_password_route.py
+++ b/tests/test_reset_password_route.py
@@ -1,27 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
 import pytest
-
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_reset_password", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def test_reset_password_page(client):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,29 +1,4 @@
-import os
 import pytest
-import importlib.util
-from pathlib import Path
-
-# Configure environment for tests
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["JWT_SECRET_KEY"] = "test-secret"
-
-app_path = Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("test_app_routes", app_path)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-app = app_module.app
-db = app_module.db
-
-
-@pytest.fixture()
-def client():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-    with app.test_client() as client:
-        yield client
-    with app.app_context():
-        db.drop_all()
 
 
 def signup_and_login(client, email="user@example.com", password="password"):


### PR DESCRIPTION
## Summary
- centralize test setup in `tests/conftest.py`
- remove duplicated boilerplate from individual tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68492e92c4188328b3ff5618e51b66a2