### PR TITLE
Update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ The application will start on `http://localhost:5000` unless a different `PORT` 
 
 ## Running Tests
 
-Tests are written with **pytest** and located in the `tests/` directory. Install dependencies and then run them with:
+Tests are written with **pytest** and located in the `tests/` directory. Install **all** packages from `requirements.txt` before running the suite:
 
 ```bash
 pytest
 ```
+
+If dependencies are missing, pytest may exit with errors such as `ModuleNotFoundError: No module named 'flask'`. Installing the full `requirements.txt` resolves this issue.
 
 The tests use an in-memory SQLite database and cover basic authentication endpoints (signup and signin).
 


### PR DESCRIPTION
## Summary
- call out that `requirements.txt` must be installed when running tests
- note potential `ModuleNotFoundError` if dependencies are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849319e93808328a4211c175fd084e9