### PR TITLE
Fix DB initialization on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Copy `.env.example` to `.env` and update the values, or export these variables i
 
 ## Database Setup
 
-Initialize the database tables before starting the server. The scripts rely on
-the same environment variables described above (at minimum `DATABASE_URL` and
-`JWT_SECRET_KEY`). Use `init_db.py` to create the schema and `seed.py` to add
-sample records:
+On first run the application will automatically create the required tables.
+If you need to reset the database or load sample data, use `init_db.py` and
+`seed.py`. They rely on the same environment variables described above (at
+minimum `DATABASE_URL` and `JWT_SECRET_KEY`):
 
 ```bash
 # Create tables (add --drop to delete existing ones)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,17 @@
 from app import app, db
 
+"""Entry point for running the development server.
+
+The database tables are automatically created on startup if they do not
+already exist. This avoids "no such table" errors when using the sign in or
+sign up routes for the first time.
+"""
+
 if __name__ == "__main__":
-    # For local development only
     import os
-    if os.getenv("INIT_DB"):
-        with app.app_context():
-            db.create_all()
+    # Always ensure tables exist so authentication routes work on first run
+    with app.app_context():
+        db.create_all()
+
     port = int(os.getenv("PORT", 5000))  # Use PORT env var if set, else default to 5000
     app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
## Summary
- create DB tables automatically when the server starts
- document automatic DB setup in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68545e3fcd94832894e4e56673c0091a