### PR TITLE
Fix redundant database initialization in main entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,14 +8,9 @@ eventlet.monkey_patch()
 # 'db' is now an unattached SQLAlchemy object from app.py
 from app import app, db, socketio 
 
-# --- 3. Initialize the DB object with the app ---
-# This associates the 'db' object with 'app' explicitly.
-with app.app_context():
-    db.init_app(app) 
-
-# --- 4. Import models/events/routes ---
-# These are imported AFTER db.init_app(app) so that when they reference 'db', 
-# the association is complete, eliminating circular import issues.
+# --- 3. Import models/events/routes ---
+# These are imported after the Flask app has been configured in app.py so
+# that when they reference 'db', the association is already complete.
 import models 
 import chat_events
 import auth_routes


### PR DESCRIPTION
## Summary
- remove the duplicate db.init_app(app) call from main.py now that the app module performs initialization
- keep module imports after the app configuration so routes and events see the configured database

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa3d6a1830832899cf92272bda4da1